### PR TITLE
feat: Add timestamps to accounts table

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -6,6 +6,7 @@ import {
   pgTable,
   serial,
   text,
+  timestamp,
 } from "drizzle-orm/pg-core";
 
 /**
@@ -21,6 +22,21 @@ export const accounts = pgTable("accounts", {
   name: text("name").notNull(),
   userId: text("user_id").notNull(),
   hint: text("hint"),
+  createdAt: timestamp("created_at", {
+    mode: "date",
+    precision: 6,
+    withTimezone: true,
+  })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", {
+    mode: "date",
+    precision: 6,
+    withTimezone: true,
+  })
+    .defaultNow()
+    .$onUpdate(() => new Date())
+    .notNull(),
 });
 
 export const ecosystems = pgTable("ecosystems", {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "awesome-debounce-promise": "^2.1.0",
     "class-variance-authority": "^0.7.0",
     "dotenv": "^16.4.5",
-    "drizzle-orm": "^0.30.4",
+    "drizzle-orm": "^0.30.7",
     "eslint-plugin-drizzle": "^0.2.3",
     "geist": "^1.2.2",
     "i18next": "^23.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,10 +2103,10 @@ drizzle-kit@^0.20.14:
     semver "^7.5.4"
     zod "^3.20.2"
 
-drizzle-orm@^0.30.4:
-  version "0.30.4"
-  resolved "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.30.4.tgz"
-  integrity sha512-kWoSMGbrOFkmkAweLTFtHJMpN+nwhx89q0mLELqT2aEU+1szNV8jrnBmJwZ0WGNp7J7yQn/ezEtxBI/qzTSElQ==
+drizzle-orm@^0.30.7:
+  version "0.30.7"
+  resolved "https://registry.yarnpkg.com/drizzle-orm/-/drizzle-orm-0.30.7.tgz#a7aeb9872af74bf4d4c589dbdb6eca56a66fc078"
+  integrity sha512-9qefSZQlu2fO2qv24piHyWFWcxcOY15//0v4j8qomMqaxzipNoG+fUBrQ7Ftk7PY7APRbRdn/nkEXWxiI4a8mw==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This PR adds `created_at` and `updated_at` timestamps to the `accounts` table. These can be used as example implementations of timestamps columns.